### PR TITLE
[#12] 토큰 관리 로직 수정

### DIFF
--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/entity/Refresh.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/entity/Refresh.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 @Entity
 class Refresh (
   @Column(name = "refresh_token", unique = true)
-  val token: String,
+  var token: String,
 ) {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/user/entity/User.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/user/entity/User.kt
@@ -25,7 +25,7 @@ class User (
   @OneToMany(mappedBy = "user")
   val blogs: MutableList<Blog>,
 
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "refresh_id")
-  val refreshToken: Refresh
+  var refreshToken: Refresh?
 )

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/user/entity/User.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/user/entity/User.kt
@@ -25,7 +25,7 @@ class User (
   @OneToMany(mappedBy = "user")
   val blogs: MutableList<Blog>,
 
-  @OneToMany
-  @JoinColumn(name = "user_id")
-  val refreshTokens: MutableList<Refresh>
+  @OneToOne
+  @JoinColumn(name = "refresh_id")
+  val refreshToken: Refresh
 )

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  #  mvc:
+  #    throw-exception-if-no-handler-found: true // ??? ? ?? ???? ??? ??? ??
+  #  web:
+  #    resources:
+  #      add-mappings: false // ?? ?? ?? ?? ???
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL57Dialect
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/chanlog?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: root
+    password: 12345678
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+jwt:
+  accessSecret: owiefwoeifwofjewfijewfoiwjfojwoiefojwf
+  refreshSecret: fweojiwefoijwefjoiwefoijwefoijfweoijw
+  domain: localhost
+
+environment: develop

--- a/src/test/kotlin/dev/chanlog/chanlogserver/global/security/jwt/JwtProviderTest.kt
+++ b/src/test/kotlin/dev/chanlog/chanlogserver/global/security/jwt/JwtProviderTest.kt
@@ -1,12 +1,15 @@
 package dev.chanlog.chanlogserver.global.security.jwt
 
+import dev.chanlog.chanlogserver.domain.user.Role
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest
+@ActiveProfiles("test")
 class JwtProviderTest (
   @Autowired
   private val jwtProvider: JwtProvider
@@ -14,7 +17,7 @@ class JwtProviderTest (
   @Test
   @DisplayName("create access token test")
   fun createAccessToken() {
-    val payload = jwtProvider.createPayload("123")
+    val payload = jwtProvider.createPayload("123", Role.ADMIN_ROLE)
     val token = jwtProvider.createToken(TokenType.ACCESS, payload)
 
     val claims = jwtProvider.parseToken(TokenType.ACCESS, token.token)
@@ -24,7 +27,7 @@ class JwtProviderTest (
   @Test
   @DisplayName("create refresh token test")
   fun createRefreshToken() {
-    val payload = jwtProvider.createPayload("123")
+    val payload = jwtProvider.createPayload("123", Role.ADMIN_ROLE)
     val token = jwtProvider.createToken(TokenType.REFRESH, payload)
 
     val claims = jwtProvider.parseToken(TokenType.REFRESH, token.token)


### PR DESCRIPTION
## 개요

- 다중 로그인은 어려울 것 같아 한 명만 로그인 할 수 있도록 수정합니다
- user에 refresh_id값이 할당되지 않는 문제가 발생했습니다
- db에 있는 refreshToken값이 계속해서 늘어나는 문제가 발생해 수정합니다

## 본문

- refresh와 user의 관계를 OneToOne으로 변경
- 로그인시 refresh를 할당하는 로직 추가
- test 전용 yml 작성

### 변경

- refresh 테이블과 user 테이블의 관계 수정
- 로그인 로직 수정

### 사용방법

- `@ActiveProfiles("test")`를 붙여주면 테스트 환경으로 바뀜