### PR TITLE
[#14] 토큰 재발급 로직 추가

### DIFF
--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/controller/AuthController.kt
@@ -3,6 +3,9 @@ package dev.chanlog.chanlogserver.domain.auth.controller
 import dev.chanlog.chanlogserver.domain.auth.dto.request.SigninRequestDto
 import dev.chanlog.chanlogserver.domain.auth.service.SigninService
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.CookieValue
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -20,4 +23,7 @@ class AuthController (
     response.addCookie(tokens.accessCookie)
     response.addCookie(tokens.refreshCookie)
   }
+
+  @PatchMapping
+  fun reissue(@CookieValue("refreshToken") refreshToken: String, authentication: Authentication) {}
 }

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/controller/AuthController.kt
@@ -1,6 +1,8 @@
 package dev.chanlog.chanlogserver.domain.auth.controller
 
+import dev.chanlog.chanlogserver.domain.auth.dto.request.ReissueTokenRequestDto
 import dev.chanlog.chanlogserver.domain.auth.dto.request.SigninRequestDto
+import dev.chanlog.chanlogserver.domain.auth.service.ReissueTokenService
 import dev.chanlog.chanlogserver.domain.auth.service.SigninService
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.Authentication
@@ -14,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/auth")
 class AuthController (
-  private val signinService: SigninService
+  private val signinService: SigninService,
+  private val reissueTokenService: ReissueTokenService
 ) {
   @PostMapping
   fun signin(@RequestBody data: SigninRequestDto, response: HttpServletResponse) {
@@ -25,5 +28,10 @@ class AuthController (
   }
 
   @PatchMapping
-  fun reissue(@CookieValue("refreshToken") refreshToken: String, authentication: Authentication) {}
+  fun reissue(@CookieValue("refreshToken") refreshToken: String, authentication: Authentication, response: HttpServletResponse) {
+    val tokens = reissueTokenService.execute(ReissueTokenRequestDto(authentication, refreshToken))
+
+    response.addCookie(tokens.accessCookie)
+    response.addCookie(tokens.refreshCookie)
+  }
 }

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/dto/request/ReissueTokenRequestDto.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/dto/request/ReissueTokenRequestDto.kt
@@ -1,0 +1,8 @@
+package dev.chanlog.chanlogserver.domain.auth.dto.request
+
+import org.springframework.security.core.Authentication
+
+data class ReissueTokenRequestDto (
+  val authentication: Authentication,
+  val refreshToken: String
+)

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/dto/response/CookiesResponseDto.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/dto/response/CookiesResponseDto.kt
@@ -2,7 +2,7 @@ package dev.chanlog.chanlogserver.domain.auth.dto.response
 
 import jakarta.servlet.http.Cookie
 
-data class SigninResponseDto (
+data class CookiesResponseDto (
   val accessCookie: Cookie,
   val refreshCookie: Cookie
 )

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/ReissueTokenService.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/ReissueTokenService.kt
@@ -1,0 +1,7 @@
+package dev.chanlog.chanlogserver.domain.auth.service
+
+import dev.chanlog.chanlogserver.domain.auth.dto.request.ReissueTokenRequestDto
+
+interface ReissueTokenService {
+  fun execute(reissueTokenDto: ReissueTokenRequestDto)
+}

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/ReissueTokenService.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/ReissueTokenService.kt
@@ -1,7 +1,8 @@
 package dev.chanlog.chanlogserver.domain.auth.service
 
 import dev.chanlog.chanlogserver.domain.auth.dto.request.ReissueTokenRequestDto
+import dev.chanlog.chanlogserver.domain.auth.dto.response.CookiesResponseDto
 
 interface ReissueTokenService {
-  fun execute(reissueTokenDto: ReissueTokenRequestDto)
+  fun execute(reissueTokenDto: ReissueTokenRequestDto): CookiesResponseDto
 }

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/SigninService.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/SigninService.kt
@@ -1,8 +1,8 @@
 package dev.chanlog.chanlogserver.domain.auth.service
 
 import dev.chanlog.chanlogserver.domain.auth.dto.request.SigninRequestDto
-import dev.chanlog.chanlogserver.domain.auth.dto.response.SigninResponseDto
+import dev.chanlog.chanlogserver.domain.auth.dto.response.CookiesResponseDto
 
 interface SigninService {
-  fun execute(data: SigninRequestDto): SigninResponseDto
+  fun execute(data: SigninRequestDto): CookiesResponseDto
 }

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/impl/ReissueTokenServiceImpl.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/impl/ReissueTokenServiceImpl.kt
@@ -1,0 +1,8 @@
+package dev.chanlog.chanlogserver.domain.auth.service.impl
+
+import dev.chanlog.chanlogserver.domain.auth.dto.request.ReissueTokenRequestDto
+import dev.chanlog.chanlogserver.domain.auth.service.ReissueTokenService
+
+class ReissueTokenServiceImpl: ReissueTokenService {
+  override fun execute(reissueTokenDto: ReissueTokenRequestDto) {}
+}

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/impl/ReissueTokenServiceImpl.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/impl/ReissueTokenServiceImpl.kt
@@ -1,8 +1,39 @@
 package dev.chanlog.chanlogserver.domain.auth.service.impl
 
 import dev.chanlog.chanlogserver.domain.auth.dto.request.ReissueTokenRequestDto
+import dev.chanlog.chanlogserver.domain.auth.dto.response.CookiesResponseDto
 import dev.chanlog.chanlogserver.domain.auth.service.ReissueTokenService
+import dev.chanlog.chanlogserver.domain.user.entity.User
+import dev.chanlog.chanlogserver.domain.user.repository.UserRepository
+import dev.chanlog.chanlogserver.global.exception.BasicException
+import dev.chanlog.chanlogserver.global.exception.ErrorCode
+import org.springframework.stereotype.Service
 
-class ReissueTokenServiceImpl: ReissueTokenService {
-  override fun execute(reissueTokenDto: ReissueTokenRequestDto) {}
+@Service
+class ReissueTokenServiceImpl(
+  private val userRepository: UserRepository,
+  private val signinServiceImpl: SigninServiceImpl
+): ReissueTokenService {
+  override fun execute(reissueTokenDto: ReissueTokenRequestDto): CookiesResponseDto {
+    val user = checkRefreshToken(reissueTokenDto)
+
+    val tokens = signinServiceImpl.createJwtToken(user)
+
+    signinServiceImpl.saveRefresh(tokens.refreshJwt, user)
+
+    val accessToken = signinServiceImpl.createCookie("accessToken", tokens.accessJwt)
+    val refreshToken = signinServiceImpl.createCookie("refreshToken", tokens.refreshJwt)
+
+    return CookiesResponseDto(accessToken, refreshToken)
+  }
+
+  private fun checkRefreshToken(reissueTokenDto: ReissueTokenRequestDto): User {
+    val user = userRepository.findById(reissueTokenDto.authentication.name)
+      .orElseThrow { BasicException(ErrorCode.INVALID_TOKEN) }
+
+    if (user.refreshToken?.token != reissueTokenDto.refreshToken)
+      throw BasicException(ErrorCode.EXPIRED_TOKEN)
+
+    return user
+  }
 }

--- a/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/impl/SigninServiceImpl.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/domain/auth/service/impl/SigninServiceImpl.kt
@@ -2,7 +2,7 @@ package dev.chanlog.chanlogserver.domain.auth.service.impl
 
 import dev.chanlog.chanlogserver.domain.auth.dto.dto.CreateJwtTokenDto
 import dev.chanlog.chanlogserver.domain.auth.dto.request.SigninRequestDto
-import dev.chanlog.chanlogserver.domain.auth.dto.response.SigninResponseDto
+import dev.chanlog.chanlogserver.domain.auth.dto.response.CookiesResponseDto
 import dev.chanlog.chanlogserver.domain.auth.entity.Refresh
 import dev.chanlog.chanlogserver.domain.auth.repository.RefreshRepository
 import dev.chanlog.chanlogserver.domain.auth.service.SigninService
@@ -17,7 +17,6 @@ import jakarta.servlet.http.Cookie
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
-import java.util.Date
 
 @Service
 class SigninServiceImpl(
@@ -31,7 +30,7 @@ class SigninServiceImpl(
   @Value("\${environment}")
   private lateinit var environment: String
 
-  override fun execute(data: SigninRequestDto): SigninResponseDto {
+  override fun execute(data: SigninRequestDto): CookiesResponseDto {
     val user = userCheck(data)
 
     val tokens = createJwtToken(user)
@@ -41,7 +40,7 @@ class SigninServiceImpl(
     val accessToken = createCookie("accessToken", tokens.accessJwt)
     val refreshToken = createCookie("refreshToken", tokens.refreshJwt)
 
-    return SigninResponseDto(accessToken, refreshToken)
+    return CookiesResponseDto(accessToken, refreshToken)
   }
 
   private fun userCheck(data: SigninRequestDto): User {
@@ -53,7 +52,7 @@ class SigninServiceImpl(
     return user
   }
 
-  private fun createJwtToken(user: User): CreateJwtTokenDto {
+  fun createJwtToken(user: User): CreateJwtTokenDto {
     val payload = jwtProvider.createPayload(user.id, user.role)
     val accessJwt = jwtProvider.createToken(TokenType.ACCESS, payload)
     val refreshJwt = jwtProvider.createToken(TokenType.REFRESH, payload)
@@ -61,7 +60,7 @@ class SigninServiceImpl(
     return CreateJwtTokenDto(accessJwt, refreshJwt)
   }
 
-  private fun saveRefresh(token: Token, user: User) {
+  fun saveRefresh(token: Token, user: User) {
     val refresh = Refresh(token.token)
     user.refreshToken?.let {
       user.refreshToken = null
@@ -73,7 +72,7 @@ class SigninServiceImpl(
     userRepository.save(user)
   }
 
-  private fun createCookie(name: String, token: Token): Cookie {
+  fun createCookie(name: String, token: Token): Cookie {
     val cookie = Cookie(name, token.token)
     cookie.isHttpOnly = true
     cookie.maxAge = token.expired

--- a/src/main/kotlin/dev/chanlog/chanlogserver/global/security/auth/provider/RefreshAuthenticationProvider.kt
+++ b/src/main/kotlin/dev/chanlog/chanlogserver/global/security/auth/provider/RefreshAuthenticationProvider.kt
@@ -16,7 +16,7 @@ class RefreshAuthenticationProvider(
 ): AuthenticationProvider {
 
   override fun authenticate(authentication: Authentication): Authentication {
-    val claims = jwtProvider.parseToken(TokenType.ACCESS, authentication.name)
+    val claims = jwtProvider.parseToken(TokenType.REFRESH, authentication.name)
 
     val user = userDetailsService.loadUserByUsername(claims)
 


### PR DESCRIPTION
## 개요

refresToken을 가지고 토큰을 재발급 할 수 있는 로직을 추가했습니다

## 본문

1. filter에서 토큰이 유효한지 검사를 한다
2. service에서 이게 존재하는 유저인지 검사를 한다
3. 토큰을 생성한다 (SigninService를 가져와서 처리함)
4. cookie로 만들어서 반환한다

### 피드백 - optional

존재하는 유저인지 검사하는 로직을 filter로 옮기는 건 어떨까??