### PR TITLE
[#39] 토큰 재발급 로직 추가

### DIFF
--- a/src/main/kotlin/dev/chanlogserver/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/auth/controller/AuthController.kt
@@ -1,10 +1,13 @@
 package dev.chanlogserver.domain.auth.controller
 
 import dev.chanlogserver.domain.auth.dto.request.LoginRequestDto
+import dev.chanlogserver.domain.auth.dto.request.ReissueRequestDto
 import dev.chanlogserver.domain.auth.service.LoginService
+import dev.chanlogserver.domain.auth.service.ReissueService
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -14,7 +17,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/auth")
 class AuthController(
-  private val loginService: LoginService
+  private val loginService: LoginService,
+  private val reissueService: ReissueService
 ) {
   @PostMapping
   fun login(@RequestBody @Valid body: LoginRequestDto, response: HttpServletResponse) {
@@ -24,7 +28,9 @@ class AuthController(
   }
 
   @PatchMapping
-  fun reissue(authentication: Authentication, response: HttpServletResponse) {
-
+  fun reissue(@CookieValue("refresh-token") refreshToken: String, authentication: Authentication, response: HttpServletResponse) {
+    val cookies = reissueService.execute(ReissueRequestDto(authentication, refreshToken))
+    response.addCookie(cookies.access)
+    response.addCookie(cookies.refresh)
   }
 }

--- a/src/main/kotlin/dev/chanlogserver/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/auth/controller/AuthController.kt
@@ -4,6 +4,8 @@ import dev.chanlogserver.domain.auth.dto.request.LoginRequestDto
 import dev.chanlogserver.domain.auth.service.LoginService
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,5 +21,10 @@ class AuthController(
     val cookies = loginService.execute(body)
     response.addCookie(cookies.access)
     response.addCookie(cookies.refresh)
+  }
+
+  @PatchMapping
+  fun reissue(authentication: Authentication, response: HttpServletResponse) {
+
   }
 }

--- a/src/main/kotlin/dev/chanlogserver/domain/auth/dto/request/ReissueRequestDto.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/auth/dto/request/ReissueRequestDto.kt
@@ -1,0 +1,8 @@
+package dev.chanlogserver.domain.auth.dto.request
+
+import org.springframework.security.core.Authentication
+
+data class ReissueRequestDto (
+  val authentication: Authentication,
+  val refreshToken: String
+)

--- a/src/main/kotlin/dev/chanlogserver/domain/auth/service/ReissueService.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/auth/service/ReissueService.kt
@@ -1,0 +1,8 @@
+package dev.chanlogserver.domain.auth.service
+
+import dev.chanlogserver.domain.auth.dto.request.ReissueRequestDto
+import dev.chanlogserver.domain.auth.dto.response.LoginResponseDto
+
+interface ReissueService {
+  fun execute(data: ReissueRequestDto): LoginResponseDto
+}

--- a/src/main/kotlin/dev/chanlogserver/domain/auth/service/impl/LoginServiceImpl.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/auth/service/impl/LoginServiceImpl.kt
@@ -49,7 +49,7 @@ class LoginServiceImpl(
     return user
   }
 
-  private fun createTokens(user: User): Tokens {
+  fun createTokens(user: User): Tokens {
     val payload = jwtProvider.createPayload(user.email, user.role)
 
     return Tokens(
@@ -58,7 +58,7 @@ class LoginServiceImpl(
     )
   }
 
-  private fun createCookie(tokenType: TokenType, token: TokenDto): Cookie {
+  fun createCookie(tokenType: TokenType, token: TokenDto): Cookie {
     val cookie = Cookie(tokenType.type, token.token)
     cookie.maxAge = token.expired
     cookie.domain = cookieDomain

--- a/src/main/kotlin/dev/chanlogserver/domain/auth/service/impl/LoginServiceImpl.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/auth/service/impl/LoginServiceImpl.kt
@@ -67,7 +67,7 @@ class LoginServiceImpl(
     userRepository.save(user)
   }
 
-  private fun createCookie(tokenType: TokenType, token: TokenDto): Cookie {
+  fun createCookie(tokenType: TokenType, token: TokenDto): Cookie {
     val cookie = Cookie(tokenType.type, token.token)
     cookie.maxAge = token.expired
     cookie.domain = cookieDomain

--- a/src/main/kotlin/dev/chanlogserver/domain/auth/service/impl/ReissueServiceImpl.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/auth/service/impl/ReissueServiceImpl.kt
@@ -1,0 +1,40 @@
+package dev.chanlogserver.domain.auth.service.impl
+
+import dev.chanlogserver.domain.auth.dto.request.ReissueRequestDto
+import dev.chanlogserver.domain.auth.dto.response.LoginResponseDto
+import dev.chanlogserver.domain.auth.service.ReissueService
+import dev.chanlogserver.domain.user.User
+import dev.chanlogserver.domain.user.repository.UserRepository
+import dev.chanlogserver.global.exception.BasicException
+import dev.chanlogserver.global.exception.ErrorCode
+import dev.chanlogserver.global.security.jwt.TokenType
+import org.springframework.stereotype.Service
+
+@Service
+class ReissueServiceImpl(
+  private val userRepository: UserRepository,
+  private val loginServiceImpl: LoginServiceImpl,
+): ReissueService {
+  override fun execute(data: ReissueRequestDto): LoginResponseDto {
+    val user = checkRefreshTokenAndFindUser(data)
+
+    val tokens = loginServiceImpl.createTokens(user)
+
+    loginServiceImpl.refreshTokenSave(tokens.refresh.token, user)
+
+    val accessCookie = loginServiceImpl.createCookie(TokenType.ACCESS, tokens.access)
+    val refreshCookie = loginServiceImpl.createCookie(TokenType.REFRESH, tokens.refresh)
+
+    return LoginResponseDto(accessCookie, refreshCookie)
+  }
+
+  fun checkRefreshTokenAndFindUser(data: ReissueRequestDto): User {
+    val user = userRepository.findById(data.authentication.name)
+      .orElseThrow { BasicException(ErrorCode.INVALID_TOKEN) }
+
+    if (user.refresh.token != data.refreshToken)
+      throw BasicException(ErrorCode.INVALID_TOKEN)
+
+    return user
+  }
+}


### PR DESCRIPTION
## 개요

토큰 재발급 로직을 추가합니다

## 본문

refresh token을 통해 토큰을 재발급하는 로직을 추가했습니다
대부분의 로직은 LoginServiceImpl에 있는 로직을 재사용했습니다

### 변경

LoginServiceImpl에 있는 몇몇 메서드들에게 private을 해제했습니다