### PR TITLE
[#47] 이미지 구조 변경

### DIFF
--- a/src/main/kotlin/dev/chanlogserver/domain/blog/Blog.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/blog/Blog.kt
@@ -19,6 +19,9 @@ class Blog (
   @ManyToOne
   @JoinColumn(name = "user_id")
   val user: User,
+
+  @OneToMany(mappedBy = "blog")
+  val images: MutableList<Image>
 ) {
   @Column(name = "created_at", nullable = false)
   val createdAt: LocalTime = LocalTime.now()

--- a/src/main/kotlin/dev/chanlogserver/domain/blog/dto/response/CreateResponseDto.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/blog/dto/response/CreateResponseDto.kt
@@ -1,10 +1,15 @@
 package dev.chanlogserver.domain.blog.dto.response
 
+import dev.chanlogserver.domain.blog.dto.dto.ImageDto
+import dev.chanlogserver.domain.image.Image
 import java.time.LocalTime
 
 data class CreateResponseDto (
   val title: String,
   val thumbnail: String,
   val content: String,
-  val createAt: LocalTime
-)
+  val createAt: LocalTime,
+  private val image: MutableIterable<Image>
+) {
+  val images = image.map { i -> ImageDto(i.url) }
+}

--- a/src/main/kotlin/dev/chanlogserver/domain/blog/service/impl/CreateBlogServiceImpl.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/blog/service/impl/CreateBlogServiceImpl.kt
@@ -27,11 +27,11 @@ class CreateBlogServiceImpl(
 
     checkDuplicateBlogTitle(data.title, user)
 
-    saveImages(data.images)
-
     val blog = createBlog(data, user)
 
-    return CreateResponseDto(blog.title, blog.thumbnail, blog.content.content, blog.createdAt)
+    val images = saveImages(data.images, blog)
+
+    return CreateResponseDto(blog.title, blog.thumbnail, blog.content.content, blog.createdAt, images)
   }
 
   private fun findUser(email: String)
@@ -43,15 +43,12 @@ class CreateBlogServiceImpl(
     if (blog != null) throw BasicException(ErrorCode.DUPLICATE_BLOG_TITLE)
   }
 
-  private fun saveImages(images: List<ImageDto>) {
-    imageRepository.saveAll(
-      images.map { image -> Image(image.image) }
-    )
-  }
+  private fun saveImages(images: List<ImageDto>, blog: Blog)
+    = imageRepository.saveAll(images.map { i -> Image(i.image, blog) })
 
   private fun createBlog(data: CreateRequestDto, user: User): Blog {
     val content = contentRepository.save(Content(data.content))
-    val newBlog = Blog(data.title, data.thumbnail, content, user)
+    val newBlog = Blog(data.title, data.thumbnail, content, user, mutableListOf())
 
     return blogRepository.save(newBlog)
   }

--- a/src/main/kotlin/dev/chanlogserver/domain/image/Image.kt
+++ b/src/main/kotlin/dev/chanlogserver/domain/image/Image.kt
@@ -1,11 +1,16 @@
 package dev.chanlogserver.domain.image
 
+import dev.chanlogserver.domain.blog.Blog
 import jakarta.persistence.*
 
 @Entity
 data class Image (
   @Column(nullable = false)
-  val url: String
+  val url: String,
+
+  @ManyToOne
+  @JoinColumn(name = "blog_id")
+  val blog: Blog
 ) {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL57Dialect
     show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
 
   datasource:
     url: jdbc:mysql://${DB_URL}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true


### PR DESCRIPTION
## 개요

image를 저장하는 구조를 변경했습니다

## 본문

blog는 여러개의 image를 가질 수 있도록 OneToMany 관계를 주었습니다(원래는 아무 관계도 없었음)

### 사용방법

나중에 batch를 돌릴 때 image에서 가리키고 있는 blog를 찾고
그 blog에서 content에 indexOf를 때려서 -1 이상이 나오면 이미지를 사용 중이라는 것이고
만약 -1이 나오면 storage에서 이미지를 지우고 db에서도 delete를 때리면 된다